### PR TITLE
Fixed picking of wrong SurfaceShape

### DIFF
--- a/src/render/Texture.js
+++ b/src/render/Texture.js
@@ -69,11 +69,6 @@ define([
             this.size = image.width * image.height * 4;
 
             gl.bindTexture(gl.TEXTURE_2D, textureId);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER,
-                isPowerOfTwo ? gl.LINEAR_MIPMAP_LINEAR : gl.LINEAR);
-
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapMode);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapMode);
 
             gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
             gl.texImage2D(gl.TEXTURE_2D, 0,
@@ -94,6 +89,9 @@ define([
 
             // Internal use only. Intentionally not documented.
             this.texParameters = {};
+            this.texParameters[gl.TEXTURE_MIN_FILTER] = isPowerOfTwo ? gl.LINEAR_MIPMAP_LINEAR : gl.LINEAR;
+            this.texParameters[gl.TEXTURE_WRAP_S] = wrapMode;
+            this.texParameters[gl.TEXTURE_WRAP_T] = wrapMode;
 
             // Internal use only. Intentionally not documented.
             // https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotrop
@@ -160,9 +158,16 @@ define([
         Texture.prototype.applyTexParameters = function (dc) {
             var gl = dc.currentGlContext;
 
-            // Configure the OpenGL texture magnification function. Use linear by default.
-            var textureMagFilter = this.texParameters[gl.TEXTURE_MAG_FILTER] || gl.LINEAR;
+            // Configure the OpenGL texture minification function. Use nearest in pickingMode or linear by default.
+            var textureMinFilter = dc.pickingMode ? gl.NEAREST : this.texParameters[gl.TEXTURE_MIN_FILTER] || gl.LINEAR;
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, textureMinFilter);
+
+            // Configure the OpenGL texture magnification function. Use nearest in pickingMode or linear by default.
+            var textureMagFilter = dc.pickingMode ? gl.NEAREST : this.texParameters[gl.TEXTURE_MAG_FILTER] || gl.LINEAR;
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, textureMagFilter);
+
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, this.texParameters[gl.TEXTURE_WRAP_S] || gl.CLAMP_TO_EDGE);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, this.texParameters[gl.TEXTURE_WRAP_T] || gl.CLAMP_TO_EDGE);
 
             // Try to enable the anisotropic texture filtering only if we have a linear magnification filter.
             // This can't be enabled all the time because Windows seems to ignore the TEXTURE_MAG_FILTER parameter when

--- a/src/shapes/SurfaceShapeTile.js
+++ b/src/shapes/SurfaceShapeTile.js
@@ -212,6 +212,21 @@ define([
                 shape.renderToTexture(dc, ctx2D, xScale, yScale, xOffset, yOffset);
             }
 
+            // Remove semi-transparent pixels, which may contain wrong pick color due to anti-aliasing
+            // TODO Disable anti-aliasing of canvas stroke in renderToTexture instead of this hack, when it will be supported by browsers
+            if (dc.pickingMode) {
+                var imageData = ctx2D.getImageData(0, 0, canvas.width, canvas.height);
+                for (var i = 3, n = canvas.width * canvas.height * 4; i < n; i += 4) {
+                    if (imageData.data[i] < 255) {
+                        imageData.data[i - 3] = 0;
+                        imageData.data[i - 2] = 0;
+                        imageData.data[i - 1] = 0;
+                        imageData.data[i] = 0;
+                    }
+                }
+                ctx2D.putImageData(imageData, 0, 0);
+            }
+
             this.gpuCacheKey = this.getCacheKey();
 
             var gpuResourceCache = dc.gpuResourceCache;


### PR DESCRIPTION
### Description of the Change
Disables anti-aliasing for `SurfaceShape` objects during picking so that a shape's anti-aliased pixel colors are not confused with the "pick" colors of other nearby shapes, otherwise, the wrong shape can be selected by the pick operation.

### Why Should This Be In Core?
Picking is an essential feature of the SDK.

### Benefits
This fix makes picking an individual `SurfaceShape` among many nearby shapes predicable.

### Potential Drawbacks
Picking performance

### Applicable Issues
Closes #27