### PR TITLE
Improve and simplify Mercator layers management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldwindjs",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "WorldWindJS is an interactive 3D globe library featuring imagery, maps, terrain and 2D projections from the Web WorldWind virtual globe SDK from NASA and ESA plus several community contributions.",
   "main": "build/dist/worldwind.min.js",
   "homepage": "https://emxsys.github.io/worldwindjs/",

--- a/src/layer/BMNGLandsatLayer.js
+++ b/src/layer/BMNGLandsatLayer.js
@@ -38,11 +38,8 @@ define([
          */
         var BMNGLandsatLayer = function () {
             // This LevelSet configuration captures the Landsat resolution of 1.38889E-04 degrees/pixel
-            TiledImageLayer.call(this,
+            TiledImageLayer.call(this, "Blue Marble & Landsat",
                 Sector.FULL_SPHERE, new Location(45, 45), 12, "image/jpeg", "BMNGLandsat256", 256, 256);
-
-            this.displayName = "Blue Marble & Landsat";
-            this.pickEnabled = false;
 
             this.urlBuilder = new WmsUrlBuilder("https://worldwind25.arc.nasa.gov/wms",
                 "BlueMarble-200405,esat", "", "1.3.0");

--- a/src/layer/BMNGLayer.js
+++ b/src/layer/BMNGLayer.js
@@ -41,11 +41,8 @@ define([
          */
         var BMNGLayer = function (layerName) {
             // This LevelSet configuration captures the Blue Marble resolution of 4.166666667E-03 degrees/pixel
-            TiledImageLayer.call(this,
+            TiledImageLayer.call(this, "Blue Marble",
                 Sector.FULL_SPHERE, new Location(45, 45), 7, "image/jpeg", layerName || "BMNG256", 256, 256);
-
-            this.displayName = "Blue Marble";
-            this.pickEnabled = false;
 
             this.urlBuilder = new WmsUrlBuilder("https://worldwind25.arc.nasa.gov/wms",
                 layerName || "BlueMarble-200405", "", "1.3.0");

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -21,21 +21,15 @@
  * @exports BingTiledImageLayer
  */
 define([
-        '../geom/Angle',
         '../util/Color',
-        '../geom/Location',
-        '../util/Offset',
         '../shapes/ScreenImage',
-        '../geom/Sector',
-        '../layer/MercatorTiledImageLayer'
+        '../layer/MercatorTiledImageLayer',
+        '../WorldWind'
     ],
-    function (Angle,
-              Color,
-              Location,
-              Offset,
+    function (Color,
               ScreenImage,
-              Sector,
-              MercatorTiledImageLayer) {
+              MercatorTiledImageLayer,
+              WorldWind) {
         "use strict";
 
         /**
@@ -50,19 +44,13 @@ define([
          * @param {String} displayName This layer's display name.
          */
         var BingTiledImageLayer = function (displayName) {
-            this.imageSize = 256;
-
-            MercatorTiledImageLayer.call(this,
-                new Sector(-85.05, 85.05, -180, 180), new Location(85.05, 180), 23, "image/jpeg", displayName,
-                this.imageSize, this.imageSize);
-
-            this.displayName = displayName;
+            MercatorTiledImageLayer.call(this, displayName, 23, "image/jpeg", displayName, 256, 1);
 
             // TODO: Picking is enabled as a temporary measure for screen credit hyperlinks to work (see Layer.render)
             this.pickEnabled = true;
 
             this.detectBlankImages = true;
-            
+
             // Set the detail control so the resolution is a close match 
             // to the resolution on the Bing maps website
             this.detailControl = 1.25;
@@ -84,16 +72,6 @@ define([
             }
         };
 
-        // Overridden from TiledImageLayer.
-        BingTiledImageLayer.prototype.createTopLevelTiles = function (dc) {
-            this.topLevelTiles = [];
-
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 1));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 1));
-        };
-
         BingTiledImageLayer.prototype.renderLogo = function (dc) {
             if (!BingTiledImageLayer.logoImage) {
                 BingTiledImageLayer.logoImage = new ScreenImage(WorldWind.configuration.bingLogoPlacement,
@@ -107,11 +85,6 @@ define([
                 BingTiledImageLayer.logoImage.render(dc);
                 BingTiledImageLayer.logoLastFrameTime = dc.timestamp;
             }
-        };
-
-        // Determines the Bing map size for a specified level number.
-        BingTiledImageLayer.prototype.mapSizeForLevel = function (levelNumber) {
-            return 256 << (levelNumber + 1);
         };
 
         return BingTiledImageLayer;

--- a/src/layer/DigitalGlobeTiledImageLayer.js
+++ b/src/layer/DigitalGlobeTiledImageLayer.js
@@ -18,20 +18,14 @@
  * @exports DigitalGlobeTiledImageLayer
  */
 define([
-        '../geom/Angle',
         '../error/ArgumentError',
         '../util/Color',
-        '../geom/Location',
         '../util/Logger',
-        '../geom/Sector',
         '../layer/MercatorTiledImageLayer'
     ],
-    function (Angle,
-              ArgumentError,
+    function (ArgumentError,
               Color,
-              Location,
               Logger,
-              Sector,
               MercatorTiledImageLayer) {
         "use strict";
 
@@ -62,12 +56,7 @@ define([
                         "The access token is null or undefined."));
             }
 
-            this.imageSize = 256;
-            displayName = displayName || "Digital Globe";
-
-            MercatorTiledImageLayer.call(this,
-                new Sector(-85.05, 85.05, -180, 180), new Location(85.05, 180), 19, "image/jpeg", displayName,
-                this.imageSize, this.imageSize);
+            MercatorTiledImageLayer.call(this, displayName || "Digital Globe", 19, "image/jpeg", displayName, 256, 1);
 
             /**
              * The map ID identifying the dataset displayed by this layer.
@@ -83,7 +72,6 @@ define([
             this.accessToken = accessToken;
             //"pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6IjljZjQwNmEyMTNhOWUyMWM5NWUzYWIwOGNhYTY2ZDViIn0.Ju3tOUUUc0C_gcCSAVpFIA";
 
-            this.displayName = displayName;
             // TODO: Picking is enabled as a temporary measure for screen credit hyperlinks to work (see Layer.render)
             this.pickEnabled = true;
 
@@ -143,21 +131,6 @@ define([
             if (this.inCurrentFrame) {
                 dc.screenCreditController.addCredit("\u00A9 Digital Globe", Color.DARK_GRAY);
             }
-        };
-
-        // Overridden from TiledImageLayer.
-        DigitalGlobeTiledImageLayer.prototype.createTopLevelTiles = function (dc) {
-            this.topLevelTiles = [];
-
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 1));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 1));
-        };
-
-        // Determines the Bing map size for a specified level number.
-        DigitalGlobeTiledImageLayer.prototype.mapSizeForLevel = function (levelNumber) {
-            return 256 << (levelNumber + 1);
         };
 
         return DigitalGlobeTiledImageLayer;

--- a/src/layer/LandsatRestLayer.js
+++ b/src/layer/LandsatRestLayer.js
@@ -52,10 +52,8 @@ define([
         var LandsatRestLayer = function (serverAddress, pathToData, displayName) {
             var cachePath = WWUtil.urlPath(serverAddress + "/" + pathToData);
 
-            TiledImageLayer.call(this, Sector.FULL_SPHERE, new Location(36, 36), 10, "image/png", cachePath, 512, 512);
+            TiledImageLayer.call(this, displayName, Sector.FULL_SPHERE, new Location(36, 36), 10, "image/png", cachePath, 512, 512);
 
-            this.displayName = displayName;
-            this.pickEnabled = false;
             this.urlBuilder = new LevelRowColumnUrlBuilder(serverAddress, pathToData);
         };
 

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -17,10 +17,7 @@
 /**
  * @exports Layer
  */
-define([
-        '../util/Logger'
-    ],
-    function (Logger) {
+define([], function () {
         "use strict";
 
         /**
@@ -29,6 +26,7 @@ define([
          * @constructor
          * @classdesc Provides an abstract base class for layer implementations. This class is not meant to be instantiated
          * directly.
+         * @param {String} displayName This layer's display name.
          */
         var Layer = function (displayName) {
 
@@ -37,7 +35,7 @@ define([
              * @type {String}
              * @default "Layer"
              */
-            this.displayName = displayName ? displayName : "Layer";
+            this.displayName = displayName || "Layer";
 
             /**
              * Indicates whether to display this layer.

--- a/src/layer/MercatorTiledImageLayer.js
+++ b/src/layer/MercatorTiledImageLayer.js
@@ -20,12 +20,14 @@
 define([
         '../util/Color',
         '../geom/Sector',
+        '../geom/Location',
         '../layer/TiledImageLayer',
         '../geom/Vec2',
         '../util/WWMath'
     ],
     function (Color,
               Sector,
+              Location,
               TiledImageLayer,
               Vec2,
               WWMath) {
@@ -38,25 +40,43 @@ define([
          * @augments TiledImageLayer
          * @classdesc Provides an abstract layer to support Mercator layers.
          *
-         * @param {Sector} sector The sector this layer covers.
-         * @param {Location} levelZeroDelta The size in latitude and longitude of level zero (lowest resolution) tiles.
+         * @param {String} displayName This layer's display name.
          * @param {Number} numLevels The number of levels to define for the layer. Each level is successively one power
          * of two higher resolution than the next lower-numbered level. (0 is the lowest resolution level, 1 is twice
          * that resolution, etc.)
          * Each level contains four times as many tiles as the next lower-numbered level, each 1/4 the geographic size.
          * @param {String} imageFormat The mime type of the image format for the layer's tiles, e.g., <em>image/png</em>.
          * @param {String} cachePath A string uniquely identifying this layer relative to other layers.
-         * @param {Number} tileWidth The horizontal size of image tiles in pixels.
-         * @param {Number} tileHeight The vertical size of image tiles in pixels.
-         * @throws {ArgumentError} If any of the specified sector, level-zero delta, cache path or image format arguments are
-         * null or undefined, or if the specified number of levels, tile width or tile height is less than 1.
+         * @param {Number} imageSize The horizontal and vertical size of image tiles in pixels.
+         * @param {Number} firstLevelOffset The level offset to skip applying one tile over whole globe and start from e.g. 8x8 tiles.
+         * @throws {ArgumentError} If any of the specified cache path or image format arguments are
+         * null or undefined, or if the specified number of levels or tile size is less than 1.
          */
-        var MercatorTiledImageLayer = function (sector, levelZeroDelta, numLevels, imageFormat, cachePath,
-                                                tileWidth, tileHeight) {
-            TiledImageLayer.call(this,
-                sector, levelZeroDelta, numLevels, imageFormat, cachePath, tileWidth, tileHeight);
+        var MercatorTiledImageLayer = function (displayName, numLevels, imageFormat, cachePath, imageSize, firstLevelOffset) {
+
+            function gudermannian(percent) {
+                var x = percent * Math.PI;
+                // var sinh = (Math.exp(x) - Math.exp(-x)) / 2;
+                var y = Math.exp(x);
+                var sinh = (y - 1 / y) / 2;
+                return Math.atan(sinh) * 180 / Math.PI;
+            }
+
+            function levelZeroDelta(firstLevelOffset) {
+                var levelZeroDelta = 360 / (1 << firstLevelOffset);
+                return new Location(levelZeroDelta / 2, levelZeroDelta);
+            }
+
+            var sector = new Sector(
+                gudermannian(-1), gudermannian(1), -180, 180
+            );
+
+            TiledImageLayer.call(this, displayName,
+                sector, levelZeroDelta(firstLevelOffset), numLevels - firstLevelOffset, imageFormat, cachePath, imageSize, imageSize);
 
             this.detectBlankImages = false;
+            this.imageSize = imageSize;
+            this.firstLevelOffset = firstLevelOffset;
 
             // These pixels are tested in retrieved images to determine whether the image is blank.
             this.testPixels = [
@@ -176,6 +196,36 @@ define([
             }
 
             return true;
+        };
+
+        /**
+         * Calculates map size in pixels for specified level.
+         *
+         * @param {Number} levelNumber The number of level to calculate map size for.
+         */
+        MercatorTiledImageLayer.prototype.mapSizeForLevel = function(levelNumber) {
+            return this.imageSize << (levelNumber + this.firstLevelOffset);
+        };
+
+        // Overridden from TiledImageLayer to add possibility to create simple child layers with URL builder built-in.
+        MercatorTiledImageLayer.prototype.resourceUrlForTile = function(tile, imageFormat) {
+            if (this.urlBuilder) {
+                return this.urlBuilder.urlForTile(tile, imageFormat);
+            } else {
+                return this.getImageSourceUrl(tile.column, tile.row, tile.level.levelNumber + this.firstLevelOffset);
+            }
+        };
+
+        /**
+         * Simple version of URL builder based on commonly used by online maps input parameters x, y and z.
+         *
+         * @param {Number} x The X coordinate of tile.
+         * @param {Number} y The Y coordinate of tile.
+         * @param {Number} z The zoom level of tile.
+         */
+        MercatorTiledImageLayer.prototype.getImageSourceUrl = function(x, y, z) {
+            // Intentionally empty. Can be override in child layer and return URL for specified tile instead of builder
+            return null;
         };
 
         return MercatorTiledImageLayer;

--- a/src/layer/RestTiledImageLayer.js
+++ b/src/layer/RestTiledImageLayer.js
@@ -61,7 +61,7 @@ define([
         var RestTiledImageLayer = function (serverAddress, pathToData, displayName, configuration) {
             var cachePath = WWUtil.urlPath(serverAddress + "/" + pathToData);
 
-            TiledImageLayer.call(this,
+            TiledImageLayer.call(this, displayName,
                 (configuration && configuration.sector) || Sector.FULL_SPHERE,
                 (configuration && configuration.levelZeroTileDelta) || new Location(45, 45),
                 (configuration && configuration.numLevels) || 5,
@@ -70,8 +70,6 @@ define([
                 (configuration && configuration.tileWidth) || 256,
                 (configuration && configuration.tileHeight) || 256);
 
-            this.displayName = displayName;
-            this.pickEnabled = false;
             this.urlBuilder = new LevelRowColumnUrlBuilder(serverAddress, pathToData);
         };
 

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -62,6 +62,7 @@ define([
          * Layers of this type are by default not pickable. Their pick-enabled flag is initialized to false.
          *
          * @augments Layer
+         * @param {String} displayName This layer's display name.
          * @param {Sector} sector The sector this layer covers.
          * @param {Location} levelZeroDelta The size in latitude and longitude of level zero (lowest resolution) tiles.
          * @param {Number} numLevels The number of levels to define for the layer. Each level is successively one power
@@ -76,7 +77,7 @@ define([
          * null or undefined, or if the specified number of levels, tile width or tile height is less than 1.
          *
          */
-        var TiledImageLayer = function (sector, levelZeroDelta, numLevels, imageFormat, cachePath, tileWidth, tileHeight) {
+        var TiledImageLayer = function (displayName, sector, levelZeroDelta, numLevels, imageFormat, cachePath, tileWidth, tileHeight) {
             if (!sector) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "TiledImageLayer", "constructor", "missingSector"));
@@ -112,7 +113,7 @@ define([
                         "The specified tile width or height is less than one."));
             }
 
-            Layer.call(this, "Tiled Image Layer");
+            Layer.call(this, displayName || "Tiled Image Layer");
 
             this.retrievalImageFormat = imageFormat;
             this.cachePath = cachePath;

--- a/src/layer/WmsLayer.js
+++ b/src/layer/WmsLayer.js
@@ -71,11 +71,8 @@ define([
                 cachePath = cachePath + timeString;
             }
 
-            TiledImageLayer.call(this, config.sector, config.levelZeroDelta, config.numLevels, config.format,
+            TiledImageLayer.call(this, config.title, config.sector, config.levelZeroDelta, config.numLevels, config.format,
                 cachePath, config.size, config.size);
-
-            this.displayName = config.title;
-            this.pickEnabled = false;
 
             this.urlBuilder = new WmsUrlBuilder(config.service, config.layerNames, config.styleNames, config.version,
                 timeString);

--- a/src/layer/heatmap/HeatMapLayer.js
+++ b/src/layer/heatmap/HeatMapLayer.js
@@ -56,9 +56,7 @@ define([
         this.tileWidth = 256;
         this.tileHeight = 256;
 
-        TiledImageLayer.call(this, new Sector(-90, 90, -180, 180), new Location(45, 45), 18, 'image/png', 'HeatMap' + WWUtil.guid(), this.tileWidth, this.tileHeight);
-
-        this.displayName = displayName;
+        TiledImageLayer.call(this, displayName, new Sector(-90, 90, -180, 180), new Location(45, 45), 18, 'image/png', 'HeatMap' + WWUtil.guid(), this.tileWidth, this.tileHeight);
 
         var data = {};
         for (var lat = -90; lat <= 90; lat++) {


### PR DESCRIPTION
### Description of the Changes
Refactor MercatorTiledImageLayer to include all general initialization, such as: sector, zero level delta, display name, image size, detectBlankImages and mapSizeForLevel calculation into parent constructor. This makes child layers avoiding unnecessary copy-paste code.
Added first level offset parameter which allows to skip several top levels to avoid displaying one tile over whole globe. 
Added alternative way of determining tile URL by overriding getImageSourceUrl function. This allows to create additional online layers by setting several parameters in constructor and overriding one function with URL builder instead of separate URL builder creation.

### Why Should This Be In Core?
This feature simplify adding new typical online layers such as Google, OSM, OTM. Wiki, etc by only specifying core parameters without unnecessary copy-paste of the same logic.
This approach already implemented in Java and will be implemented in Android.

### Benefits
Simple mercator online sources creation.

### Potential Drawbacks
Less flexibility of constructor.

### Applicable Issues
Closes #29
